### PR TITLE
Update parse VS parseBlock documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,21 @@ See [Releases](https://github.com/pavittarx/editorjs-html/releases)
 * Delimiter 
 * Paragraph
 
-## Parse Single Clean Data Blocks
+## Parse Entire EditorJS Data Object
+
+```js
+  const edjsParser = edjsHTML();
+  const HTML = edjsParser.parse(editorjs_data);
+  // returns array of html strings per block
+  console.log(HTML);
+```
+
+## Parse Single Clean Data Block
 
 ```js
   const edjsParser = edjsHTML();
   const blockHTML = edjsParser.parseBlock(editorjs_clean_data_block);
-
+  // returns string of html for this block
   console.log(blockHTML);
 ```
 


### PR DESCRIPTION
I originally had confusion on `.parse` returning an array and not a string of *ALL* the html. Hope this helps someone in the future.