### PR TITLE
Add types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.4.2",
   "description": "",
   "main": "build/edjsHTML.node.js",
+  "types": "build/app.d.ts",
   "scripts": {
     "test": "npm run build && node test/test",
     "build": "rollup --config"


### PR DESCRIPTION
According to  [TypeScript docs](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package), types property should be included in package.json to indicate the main declaration file. Otherwise, TypeScript cannot find the declarations.