### PR TITLE
Nesting List: Nested <ol> and <ul> should be child of <li> tag

### DIFF
--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -71,7 +71,7 @@ const transforms: transforms = {
 
         let list = "";
         if (item.items) list = recursor(item.items, listStyle);
-        if (item.content) return `<li> ${item.content} </li>` + list;
+        if (item.content) return `<li> ${item.content} ${list} </li>`;
       });
 
       return `<${listStyle}>${list.join("")}</${listStyle}>`;


### PR DESCRIPTION
This PR fix the issue mentioned in #49 .

As the issue addressed, nested `<ol>` and `<ul>` should be child of `<li>`, not sibling.